### PR TITLE
Correct variable references in bin file

### DIFF
--- a/bin/optimage
+++ b/bin/optimage
@@ -14,8 +14,8 @@ optimage(options, function(err, res){
     var stderr = res.stderr;
 
     if (stderr.indexOf('already optimized') !== -1 || saved < 10) {
-        console.log(options.inputFile, "(already optimized)", ">", outputFile);
+        console.log(options.inputFile, "(already optimized)", ">", options.outputFile);
     }else{
-        console.log(options.inputFile, "(saved "+ saved+ "Bytes)", ">", outputFile);
+        console.log(options.inputFile, "(saved "+ saved+ "Bytes)", ">", options.outputFile);
     }
 })

--- a/bin/optimage
+++ b/bin/optimage
@@ -5,8 +5,8 @@ var optimage = require('../');
 var argv = process.argv;
 
 var options = {
-    inputFile: argv[3],
-    outputFile: argv[4]
+    inputFile: argv[2],
+    outputFile: argv[3]
 };
 
 optimage(options, function(err, res){


### PR DESCRIPTION
Hi, I started using your library to compress images and save some precious disk space and I faced a couple of issues when using it from the command line interface.
First, it would always fail with a `ReferenceError: outputFile is not defined`. Taking a look at the source I noticed outputFile is not a variable defined in the scope but a key of the object options. Using `options.outputFile` fixes the issue.
I also noticed the references for the input and output files were also wrong. Node executable file is always given "node" (even when being run by itself with execution permissions) and its own filename as the first two elements of argv array. Since optimage file doesn't seem to take any other argument than input and output files, they should be refereced as the third and fourth elements in argv array.

Let me know if you want me to make any other changes to get this merged. :bow:
